### PR TITLE
Add support for LLM servers that don't include `usage` or token counts in their responses

### DIFF
--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -765,10 +765,10 @@ async function queryOpenAI(
   const durationMs = Date.now() - start
   const durationMsIncludingRetries = Date.now() - startIncludingRetries
 
-  const inputTokens = response.usage.prompt_tokens
-  const outputTokens = response.usage.completion_tokens
-  const cacheReadInputTokens = response.usage.prompt_token_details?.cached_tokens ?? 0
-  const cacheCreationInputTokens = response.usage.prompt_token_details?.cached_tokens ?? 0
+  const inputTokens = response.usage?.prompt_tokens ?? 0
+  const outputTokens = response.usage?.completion_tokens ?? 0
+  const cacheReadInputTokens = response.usage?.prompt_token_details?.cached_tokens ?? 0
+  const cacheCreationInputTokens = response.usage?.prompt_token_details?.cached_tokens ?? 0
   const costUSD =
     (inputTokens / 1_000_000) * SONNET_COST_PER_MILLION_INPUT_TOKENS +
     (outputTokens / 1_000_000) * SONNET_COST_PER_MILLION_OUTPUT_TOKENS +
@@ -784,9 +784,9 @@ async function queryOpenAI(
       ...response,
       content: normalizeContentFromAPI(response.content),
       usage: {
-        input_tokens: response.usage.prompt_tokens,
-        output_tokens: response.usage.completion_tokens,
-        cache_read_input_tokens: response.usage.prompt_token_details?.cached_tokens ?? 0,
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_read_input_tokens: cacheReadInputTokens,
         cache_creation_input_tokens: 0
       },
     },


### PR DESCRIPTION
With this patch, I'm able to use Anon Kode with a local Open AI-compliant server ([LM Studio](https://lmstudio.ai)). It was necessary because LM Studio [doesn't reply with a usage object](https://github.com/lmstudio-ai/lms/issues/98) (presumably because token pricing doesn't usually matter if you're self-hosting)



