### PR TITLE
feat: add support for DeepSeek API's reasoning_content in message str…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.30]
+- support deepseek api reasoning model's reasoning content
+
 ## [v0.0.29]
 - remove Anthropic from /models since it doesn't work yet
 

--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -403,7 +403,16 @@ async function handleMessageStream(
     })
   }
 
-  if(finalResponse.choices[0]?.message.content) {
+  // NOTE: For openrouter, the key for its returned reasoning process is reasoning_content 
+  if (finalResponse.choices[0]?.message.reasoning_content) {
+    contentBlocks.push({
+      type: 'thinking',
+      thinking: finalResponse.choices[0]?.message.reasoning_content,
+      signature: '',
+    })
+  }
+
+  if (finalResponse.choices[0]?.message.content) {
     contentBlocks.push({
       type: 'text',
       text: finalResponse.choices[0]?.message.content,


### PR DESCRIPTION
…eam processing

Added logic to handle `reasoning_content` field from DeepSeek API's reasoning model responses. This introduces a new `thinking` content block type containing the reasoning process details when available. The changelog has been updated to document this new feature in version 0.0.30. The existing content handling for standard `content` field remains intact.