### PR TITLE
Some models do not understand structured tool calls with JSON as paypload.

### DIFF
--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -240,6 +240,20 @@ export async function getCompletion(
 
   await applyModelErrorFixes(opts, baseURL)
 
+  if (config.primaryProvider === 'custom') {
+    opts.messages = opts.messages.map(msg => {
+      if (msg.role === 'tool' && 
+          Array.isArray(msg.content)
+        ) {
+        return {
+          ...msg,
+          content: msg.content.map(c => c.text).join('\n\n')
+        };
+      }
+      return msg;
+    });
+  }
+
   try {
     if (opts.stream) {
       const response = await fetch(`${baseURL}/chat/completions`, {


### PR DESCRIPTION
I've tried several LLM models using https://build.nvidia.com/ and LM Studio and noticed that API does not support structured tool calls where content includes JSON object. So here is a patch for that:

- Convert tool message content from array to string format when using custom provider
- Ensures compatibility with custom provider's message format expectations

I'm not sure if that is correct way to solve the problem. I would expect that model selection will lead to using slightly different API between Anthropic and OpenAI compatible models.

Let me know if that fix is correct or not.