### PR TITLE
feat: Add MCP command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,6 +10,7 @@ import init from './commands/init'
 import listen from './commands/listen'
 import login from './commands/login'
 import logout from './commands/logout'
+import mcp from './commands/mcp'
 import * as model from './commands/model'
 import onboarding from './commands/onboarding'
 import pr_comments from './commands/pr_comments'
@@ -82,6 +83,7 @@ const COMMANDS = memoize((): Command[] => [
   doctor,
   help,
   init,
+  mcp,
   model,
   onboarding,
   pr_comments,

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,0 +1,44 @@
+import type { Command } from '../commands'
+import { listMCPServers, getClients } from '../services/mcpClient'
+import { PRODUCT_COMMAND } from '../constants/product'
+import chalk from 'chalk'
+import { getTheme } from '../utils/theme'
+
+const mcp = {
+  type: 'local',
+  name: 'mcp',
+  description: 'Show MCP server connection status',
+  isEnabled: true,
+  isHidden: false,
+  async call() {
+    const servers = listMCPServers()
+    const clients = await getClients()
+    const theme = getTheme()
+    
+    if (Object.keys(servers).length === 0) {
+      return `⎿  No MCP servers configured. Run \`${PRODUCT_COMMAND} mcp\` to learn about how to configure MCP servers.`
+    }
+
+    // Sort servers by name and format status with colors
+    const serverStatusLines = clients
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(client => {
+        const isConnected = client.type === 'connected'
+        const status = isConnected ? 'connected' : 'disconnected'
+        const coloredStatus = isConnected 
+          ? chalk.hex(theme.success)(status)
+          : chalk.hex(theme.error)(status)
+        return `⎿  • ${client.name}: ${coloredStatus}`
+      })
+
+    return [
+      '⎿  MCP Server Status',
+      ...serverStatusLines
+    ].join('\n')
+  },
+  userFacingName() {
+    return 'mcp'
+  },
+} satisfies Command
+
+export default mcp


### PR DESCRIPTION
## Summary
- Adds the `mcp` command to the interacitve CLI.
- Provides the basic structure for managing MCP servers.

🤖 Generated with Anon Kode