### PR TITLE
feat: Include model name in generated commit message attribution

### DIFF
--- a/src/tools/BashTool/BashTool.tsx
+++ b/src/tools/BashTool/BashTool.tsx
@@ -12,6 +12,7 @@ import { isInDirectory } from '../../utils/file'
 import { logError } from '../../utils/log'
 import { PersistentShell } from '../../utils/PersistentShell'
 import { getCwd, getOriginalCwd } from '../../utils/state'
+import { getGlobalConfig } from '../../utils/config'
 import BashToolResultMessage from './BashToolResultMessage'
 import { BANNED_COMMANDS, PROMPT } from './prompt'
 import { formatOutput, getCommandFilePaths } from './utils'
@@ -67,7 +68,10 @@ export const BashTool = {
     }
   },
   async prompt() {
-    return PROMPT
+    const config = getGlobalConfig()
+    const modelName = config.largeModelName || '<Unknown Model>'
+    // Substitute the placeholder in the static PROMPT string
+    return PROMPT.replace(/{MODEL_NAME}/g, modelName) 
   },
   isReadOnly() {
     return false

--- a/src/tools/BashTool/prompt.ts
+++ b/src/tools/BashTool/prompt.ts
@@ -93,7 +93,7 @@ When the user asks you to create a new git commit, follow these steps carefully:
 </commit_analysis>
 
 4. Create the commit with a message ending with:
-🤖 Generated with ${PRODUCT_NAME}
+🤖 Generated with ${PRODUCT_NAME} & {MODEL_NAME}
 Co-Authored-By: ${PRODUCT_NAME} <noreply@${PRODUCT_NAME}.com>
 
 - In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
@@ -101,7 +101,7 @@ Co-Authored-By: ${PRODUCT_NAME} <noreply@${PRODUCT_NAME}.com>
 git commit -m "$(cat <<'EOF'
    Commit message here.
 
-   🤖 Generated with ${PRODUCT_NAME}
+   🤖 Generated with ${PRODUCT_NAME} & {MODEL_NAME}
    Co-Authored-By: ${PRODUCT_NAME} <noreply@${PRODUCT_NAME}.com>
    EOF
    )"
@@ -164,7 +164,7 @@ gh pr create --title "the pr title" --body "$(cat <<'EOF'
 ## Test plan
 [Checklist of TODOs for testing the pull request...]
 
-🤖 Generated with ${process.env.USER_TYPE === 'ant' ? `[${PRODUCT_NAME}](${PRODUCT_URL})` : PRODUCT_NAME}
+🤖 Generated with ${process.env.USER_TYPE === 'ant' ? `[${PRODUCT_NAME}](${PRODUCT_URL})` : PRODUCT_NAME} & {MODEL_NAME}
 EOF
 )"
 </example>


### PR DESCRIPTION
Adds the name of the AI model used to the footer of commit messages generated by Anon Kode. This enhances traceability by indicating which model contributed to the commit.

🤖 Generated with Anon Kode & gemini-2.5-pro-exp-03-25
Co-Authored-By: Anon Kode <noreply@Anon Kode.com>